### PR TITLE
Version 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ This python module provides Zabbix monitoring support for Azure resources.
 
 
 
+
 ## Requirements
 
 - Zabbix agent
 - pip
 - adal (installed automatically as dependency)
 - azure (installed automatically as dependency)
+
 
 
 
@@ -27,6 +29,7 @@ pip install https://github.com/digiaiiris/zabbix-azure-monitoring/releases/downl
 
 
 
+
 ## Usage
 
 ### Discovery
@@ -34,6 +37,7 @@ pip install https://github.com/digiaiiris/zabbix-azure-monitoring/releases/downl
 Item Syntax | Description | Units |
 ----------- | ----------- | ----- |
 azure.discover[configuration_file, resource_group, provider_name, resource_type, resource] | Discover metrics from Azure resources | {#METRIC_CATEGORY}, {#METRIC_NAME} |
+
 
 
 ### Azure Metrics
@@ -44,31 +48,36 @@ azure.metric.timeshift[configuration_file, resource_group, provider_name, resour
 
 
 
-### Retrieving available resources
+
+## Retrieving available resources
 
 Available resources can be retrieved using the Azure CLI application.
 
 
-**Download and install the Azure CLI**
+
+### Download and install the Azure CLI
 
 https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
 
 
-**Authenticate using the Azure CLI**
+
+### Authenticate using the Azure CLI
 ```
 az login --service-principal -u "<subscription_id>" -p "<path_to_pem_file>" --tenant "<tenant_id>"
 ```
 
 
-**List available resources using Azure CLI**
+
+### List available resources using Azure CLI
 
 `az resource list`
 
 
 
+
 ## Examples
 
-**Example configuration file**
+### Example configuration file
 ```
 {
     "application_id": "<application_id>",
@@ -80,29 +89,33 @@ az login --service-principal -u "<subscription_id>" -p "<path_to_pem_file>" --te
 ```
 
 
-**PEM-file thumbprint can be retrieved using OpenSSL command**
+
+### PEM-file thumbprint can be retrieved using OpenSSL command
 ```
 openssl x509 -in <path_to_pem_file> -fingerprint -noout
 ```
 
 
-**List available metrics from resource**
+
+### List available metrics from resource
 ```
 azure_discovery -c "<path_to_config_file>" -g "<resource_group>" -p "<provider_name>" -t "<provider_type>" -r "<resource_name>"
 ```
 
 
-**Retrieve metric**
+
+### Retrieve metric
 ```
-azure_discovery -c "<path_to_config_file>" -g "<resource_group>" -p "<provider_name>" -t "<provider_type>" -r "<resource_name>" "<metric>" <statistic> <timegrain>
+azure_metric -c "<path_to_config_file>" -g "<resource_group>" -p "<provider_name>" -t "<provider_type>" -r "<resource_name>" "<metric>" <statistic> <timegrain> --timeshift <timeshift>
 ```
 
 
-**Possible values for statistic-argument**
 
-`Average, Count, Minimum, Maximum, Total`
+### Possible values for statistic-argument
+
+Average, Count, Minimum, Maximum, Total
 
 
-**Possible values for timegrain-argument**
 
-`PT1M, PT1H, P1D`
+### Possible values for timegrain-argument
+PT1M, PT1H, P1D

--- a/python/ic_azure/azure_metric.py
+++ b/python/ic_azure/azure_metric.py
@@ -120,9 +120,9 @@ def main(args=None):
         args.timeshift
     )
 
-    # Do not print value if it is below zero
+    # If value was None, print zero. Otherwise print retrieved value.
     if not value:
-        print("")
+        print(0)
     else:
         print(value)
 

--- a/python/ic_azure/azure_metric.py
+++ b/python/ic_azure/azure_metric.py
@@ -22,7 +22,7 @@ class AzureMetric(object):
 
         # Declare variables
         interval = -1
-        ret_val = None
+        ret_val = -1
 
         # Retrieve interval and timeunit
         result = re.search(r"^PT?([\d]+)([DHM])$", timegrain)
@@ -76,7 +76,7 @@ class AzureMetric(object):
         for item in metrics_data.value:
             for timeserie in item.timeseries:
                 for data in timeserie.data:
-                    ret_val = data.total
+                    ret_val = data.__dict__.get(statistic.lower())
 
         return ret_val
 
@@ -123,6 +123,8 @@ def main(args=None):
     # If value was None, print zero. Otherwise print retrieved value.
     if not value:
         print(0)
+    elif value == -1:
+        print("")
     else:
         print(value)
 


### PR DESCRIPTION
- If retrieved metric value is None, print zero. Otherwise Zabbix will treat empty string as an error.
- Improved readability of README.md and fixed one error.