### PR TITLE
Version 1.6.1, ability to set a timeout for queries in seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This python module provides Zabbix monitoring support for Azure resources.
 1. Install the python module using pip.
 
 ```
-pip install https://github.com/digiaiiris/zabbix-azure-monitoring/releases/download/1.6.0/azure-monitoring-1.6.0.tar.gz
+pip install https://github.com/digiaiiris/zabbix-azure-monitoring/releases/download/1.6.1/azure-monitoring-1.6.1.tar.gz
 ```
 
 2. Copy the [Zabbix agent configuration](etc/zabbix/zabbix_agent.d/ic_azure.conf) to /etc/zabbix/zabbix_agent.d directory.

--- a/python/ic_azure/azure_client.py
+++ b/python/ic_azure/azure_client.py
@@ -56,6 +56,12 @@ class AzureClient(object):
         if config.get("resources"):
             self.resources = config.get("resources")
 
+        # Set script timeout
+        if config.get("timeout"):
+            self.timeout = config["timeout"]
+        else:
+            self.timeout = 5
+
         # Create authentication context
         login_endpoint = AZURE_PUBLIC_CLOUD.endpoints.active_directory
         context = adal.AuthenticationContext("{}/{}".format(
@@ -134,12 +140,14 @@ class AzureClient(object):
                 response = requests.get(
                     headers=headers,
                     json=json,
+                    timeout=self.timeout,
                     url=url
                 )
             elif method == "POST":
                 response = requests.post(
                     headers=headers,
                     json=json,
+                    timeout=self.timeout,
                     url=url
                 )
             else:

--- a/python/ic_azure/azure_metric.py
+++ b/python/ic_azure/azure_metric.py
@@ -6,6 +6,11 @@ from argparse import ArgumentParser
 import re
 import sys
 
+# Azure imports
+from msrest.exceptions import AuthenticationError, ClientRequestError, \
+    DeserializationError, HttpOperationError, SerializationError, \
+    TokenExpiredError, ValidationError
+
 # Azure client imports
 from azure_client import AzureClient
 
@@ -78,8 +83,26 @@ class AzureMetric(object):
                 filter=filter,
                 timeout=self.timeout
             )
-        except TypeError as e:
-            print("Operation timed out. {}".format(e))
+        except AuthenticationError as e:
+            print("Client request failed to authenticate. {}".format(e))
+            sys.exit(1)
+        except ClientRequestError as e:
+            print("Client request failed. {}".format(e))
+            sys.exit(1)
+        except DeserializationError as e:
+            print("Error raised during response deserialization. {}".format(e))
+            sys.exit(1)
+        except HttpOperationError as e:
+            print("HTTP operation error. {}".format(e))
+            sys.exit(1)
+        except SerializationError as e:
+            print("Error raised during request serialization. {}".format(e))
+            sys.exit(1)
+        except TokenExpiredError as e:
+            print("OAuth token expired. {}".format(e))
+            sys.exit(1)
+        except ValidationError as e:
+            print("Request parameter validation failed. {}".format(e))
             sys.exit(1)
         except Exception as e:
             print("An exception occured. {}".format(e))

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name="azure-monitoring",
-    version="1.6.0",
+    version="1.6.1",
     author="Antti-Pekka Meronen",
     author_email="antti-pekka.meronen@digia.com",
     description="Monitoring scripts for Azure services",


### PR DESCRIPTION
In Kusto- and Logic Apps-queries, setting the timeout is straightforward. We can use the requests library's keyword argument "timeout".

While retrieving Application Insights metrics we need to pass a keyword argument called "operation_config" which enables us to set a timeout for the operation. This is detailed here:
https://docs.microsoft.com/en-us/azure/python/python-sdk-azure-operation-config

The exception we receive is a TypeError, not a Timeout as in requests library. So I catched the exception and output a timeout error message instead. The whole exception is detailed below:

```
Traceback (most recent call last):
  File "/path/to/git/zabbix-azure-monitoring/python/ic_azure/azure_metric.py", line 137, in <module>
    main()
  File "/path/to/git/zabbix-azure-monitoring/python/ic_azure/azure_metric.py", line 123, in main
    args.role_name
  File "/path/to/git/zabbix-azure-monitoring/python/ic_azure/azure_metric.py", line 76, in get_metric
    timeout=1
  File "/usr/lib/python2.7/site-packages/azure/mgmt/monitor/operations/metrics_operations.py", line 135, in list
    response = self._client.send(request, header_parameters, stream=False, **operation_config)
  File "/usr/lib/python2.7/site-packages/msrest/service_client.py", line 336, in send
    pipeline_response = self.config.pipeline.run(request, **kwargs)
  File "/usr/lib/python2.7/site-packages/msrest/pipeline/__init__.py", line 197, in run
    return first_node.send(pipeline_request, **kwargs)  # type: ignore
  File "/usr/lib/python2.7/site-packages/msrest/pipeline/__init__.py", line 150, in send
    response = self.next.send(request, **kwargs)
  File "/usr/lib/python2.7/site-packages/msrest/pipeline/requests.py", line 72, in send
    return self.next.send(request, **kwargs)
  File "/usr/lib/python2.7/site-packages/msrest/pipeline/requests.py", line 137, in send
    return self.next.send(request, **kwargs)
  File "/usr/lib/python2.7/site-packages/msrest/pipeline/__init__.py", line 150, in send
    response = self.next.send(request, **kwargs)
  File "/usr/lib/python2.7/site-packages/msrest/pipeline/requests.py", line 193, in send
    self.driver.send(request.http_request, **kwargs)
  File "/usr/lib/python2.7/site-packages/msrest/universal_http/requests.py", line 328, in send
    return super(RequestsHTTPSender, self).send(request, **requests_kwargs)
  File "/usr/lib/python2.7/site-packages/msrest/universal_http/requests.py", line 137, in send
    **kwargs)
  File "/usr/lib/python2.7/site-packages/requests/sessions.py", line 486, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python2.7/site-packages/requests/sessions.py", line 598, in send
    r = adapter.send(request, **kwargs)
  File "/usr/lib/python2.7/site-packages/requests/adapters.py", line 370, in send
    timeout=timeout
  File "/usr/lib/python2.7/site-packages/urllib3/connectionpool.py", line 720, in urlopen
    method, url, error=e, _pool=self, _stacktrace=sys.exc_info()[2]
  File "/usr/lib/python2.7/site-packages/urllib3/util/retry.py", line 380, in increment
    total -= 1
TypeError: unsupported operand type(s) for -=: 'Retry' and 'int'
```