### PR TITLE
Azure metrics query filter and metrics namespace.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This python module provides Zabbix monitoring support for Azure resources.
 1. Install the python module using pip.
 
 ```
-pip3 install https://github.com/digiaiiris/zabbix-azure-monitoring/releases/download/1.9.3/azure-monitoring-1.9.3.tar.gz
+pip3 install https://github.com/digiaiiris/zabbix-azure-monitoring/releases/download/1.10.0/azure-monitoring-1.10.0.tar.gz
 ```
 
 2. Copy the [Zabbix agent configuration](etc/zabbix/zabbix_agent.d/ic_azure.conf) to /etc/zabbix/zabbix_agent.d directory.

--- a/etc/zabbix/zabbix_agentd.d/ic_azure.conf
+++ b/etc/zabbix/zabbix_agentd.d/ic_azure.conf
@@ -1,8 +1,8 @@
 # Azure metric retrieval (configuration file, resource, metric, statistic, timegrain (optional: filter, metric-namespace, timeshift)
 UserParameter=azure.metric[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" $([ -n "$6" ] && echo "--timeshift $6")
 UserParameter=azure.metric.filter[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --filter "$6" $([ -n "$7" ] && echo "--timeshift $7")
-UserParameter=azure.metric.metric.namespace[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --metric-namespace "$6" $([ -n "$7" ] && echo "--timeshift $7")
-UserParameter=azure.metric.metric.namespace.filter[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --metric-namespace "$6" --filter "$7" $([ -n "$8" ] && echo "--timeshift $8")
+UserParameter=azure.metric.namespace[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --metric-namespace "$6" $([ -n "$7" ] && echo "--timeshift $7")
+UserParameter=azure.metric.namespace.filter[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --metric-namespace "$6" --filter "$7" $([ -n "$8" ] && echo "--timeshift $8")
 UserParameter=azure.metric.roleinstance[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --filter "cloud/roleInstance eq '$6'" $([ -n "$7" ] && echo "--timeshift $7")
 UserParameter=azure.metric.rolename[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --filter "cloud/roleName eq '$6'" $([ -n "$7" ] && echo "--timeshift $7")
 

--- a/etc/zabbix/zabbix_agentd.d/ic_azure.conf
+++ b/etc/zabbix/zabbix_agentd.d/ic_azure.conf
@@ -1,10 +1,10 @@
-# Azure metric retrieval (configuration file, resource, metric, statistic, timegrain (optional: timeshift, instance name, role name)
-UserParameter=azure.metric[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5"
-UserParameter=azure.metric.timeshift[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --timeshift "$6"
-UserParameter=azure.metric.roleinstance[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --instance-name "$6"
-UserParameter=azure.metric.rolename[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --role-name "$6"
-UserParameter=azure.metric.roleinstance.timeshift[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --instance-name "$6" --timeshift "$7"
-UserParameter=azure.metric.rolename.timeshift[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --role-name "$6" --timeshift "$7"
+# Azure metric retrieval (configuration file, resource, metric, statistic, timegrain (optional: filter, metric-namespace, timeshift)
+UserParameter=azure.metric[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" $([ -n "$6" ] && echo "--timeshift $6")
+UserParameter=azure.metric.filter[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --filter "$6" $([ -n "$7" ] && echo "--timeshift $7")
+UserParameter=azure.metric.metric.namespace[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --metric-namespace "$6" $([ -n "$7" ] && echo "--timeshift $7")
+UserParameter=azure.metric.metric.namespace.filter[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --metric-namespace "$6" --filter "$7" $([ -n "$8" ] && echo "--timeshift $8")
+UserParameter=azure.metric.roleinstance[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --filter "cloud/roleInstance eq '$6'" $([ -n "$7" ] && echo "--timeshift $7")
+UserParameter=azure.metric.rolename[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --filter "cloud/roleName eq '$6'" $([ -n "$7" ] && echo "--timeshift $7")
 
 # Azure metric discovery (configuration file, resource)
 UserParameter=azure.discover.metrics[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_discover_metrics "$1" "$2"

--- a/etc/zabbix/zabbix_agentd.d/ic_azure.conf
+++ b/etc/zabbix/zabbix_agentd.d/ic_azure.conf
@@ -3,8 +3,16 @@ UserParameter=azure.metric[*],source /opt/virtualenv/zabbix-azure-monitoring/bin
 UserParameter=azure.metric.filter[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --filter "$6" $([ -n "$7" ] && echo "--timeshift $7")
 UserParameter=azure.metric.namespace[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --metric-namespace "$6" $([ -n "$7" ] && echo "--timeshift $7")
 UserParameter=azure.metric.namespace.filter[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --metric-namespace "$6" --filter "$7" $([ -n "$8" ] && echo "--timeshift $8")
+
+# Azure metric retrieval using pre-defined filters (configuration file, resource, metric, statistic, timegrain, filter, (optional: timeshift)
 UserParameter=azure.metric.roleinstance[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --filter "cloud/roleInstance eq '$6'" $([ -n "$7" ] && echo "--timeshift $7")
 UserParameter=azure.metric.rolename[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --filter "cloud/roleName eq '$6'" $([ -n "$7" ] && echo "--timeshift $7")
+UserParameter=azure.metric.phase[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --filter "phase eq '$6'" $([ -n "$7" ] && echo "--timeshift $7")
+UserParameter=azure.metric.status[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --filter "Status eq '$6'" $([ -n "$7" ] && echo "--timeshift $7")
+
+# Azure metric retrieval using metric namespace and pre-defined filters (configuration file, resource, metric, statistic, timegrain, metric-namespace, filter, (optional: timeshift)
+UserParameter=azure.metric.namespace.phase[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --metric-namespace "$6" --filter "phase eq '$7'" $([ -n "$8" ] && echo "--timeshift $8")
+UserParameter=azure.metric.namespace.status[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_metric "$1" "$2" "$3" "$4" "$5" --metric-namespace "$6" --filter "Status eq '$7'" $([ -n "$8" ] && echo "--timeshift $8")
 
 # Azure metric discovery (configuration file, resource)
 UserParameter=azure.discover.metrics[*],source /opt/virtualenv/zabbix-azure-monitoring/bin/activate && azure_discover_metrics "$1" "$2"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,4 +3,5 @@ azure-identity==1.5
 azure-mgmt-monitor==2.0
 azure-mgmt-resource==16.1
 msrestazure==0.6
+PyJWT==1.7
 requests==2.25

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name="azure-monitoring",
-    version="1.9.3",
+    version="1.10.0",
     author="Antti-Pekka Meronen",
     author_email="antti-pekka.meronen@digia.com",
     description="Monitoring scripts for Azure services",


### PR DESCRIPTION
We need to be able to provide filter and metric namespace parameters in order to retrieve metrics for Azure Kubernetes.