### PR TITLE
IIRISPV-5 Use one hours instead of one day for dimension discovery be…

### DIFF
--- a/python/ic_azure/azure_discover_dimensions.py
+++ b/python/ic_azure/azure_discover_dimensions.py
@@ -25,7 +25,7 @@ class AzureDiscoverRoles(object):
 
         # Calculate start/end times
         end_time = datetime.utcnow() - timedelta(minutes=5)
-        start_time = end_time - timedelta(days=1)
+        start_time = end_time - timedelta(hours=1)
 
         # Read resource from config using key
         if not resource.startswith("/subscriptions"):
@@ -38,7 +38,7 @@ class AzureDiscoverRoles(object):
                 start_time.strftime('%Y-%m-%dT%H:%M:%SZ'),
                 end_time.strftime('%Y-%m-%dT%H:%M:%SZ')
             ),
-            interval="P1D",
+            interval="PT1H",
             metricnames=metric,
             aggregation="Total",
             result_type="Metadata",


### PR DESCRIPTION
…cause Azure complains of too long time graints

We had a problem with a few Azure metric dimensions discoveries. Azure complained:
```
azure.core.exceptions.HttpResponseError: (BadRequest) Commonly allowed time grains: 00:01:00,00:05:00,00:15:00,00:30:00,01:00:00,06:00:00,12:00:00 between metrics: node_cpu_usage_percentage, can not support requested time grain: 1.00:00:00 please adjust your interval parameter to use one of the common grains, TraceId: {56ecd9ee-00c4-48e4-9f09-798927c5f6f2}
Code: BadRequest
Message: Commonly allowed time grains: 00:01:00,00:05:00,00:15:00,00:30:00,01:00:00,06:00:00,12:00:00 between metrics: node_cpu_usage_percentage, can not support requested time grain: 1.00:00:00 please adjust your interval parameter to use one of the common grains
```

I think Azure typically logs metrics every minute or 10 minutes and so 1 hour time grain for discovery should be enough.